### PR TITLE
Implement HTTP server and WHERE in SELECT

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -117,6 +117,22 @@ func TestAdditionalTypes(t *testing.T) {
 	}
 }
 
+func TestSelectWhere(t *testing.T) {
+	engine.Tables = make(map[string]*engine.Table)
+
+	_, _ = engine.HandleCommand("CREATE TABLE users (id INT, name TEXT)")
+	_, _ = engine.HandleCommand("INSERT INTO users VALUES (1, 'Alice')")
+	_, _ = engine.HandleCommand("INSERT INTO users VALUES (2, 'Bob')")
+
+	result, err := engine.HandleCommand("SELECT name FROM users WHERE id=2")
+	if err != nil {
+		t.Fatalf("select with where failed: %v", err)
+	}
+	if !strings.Contains(result, "Bob") || strings.Contains(result, "Alice") {
+		t.Errorf("unexpected select result: %s", result)
+	}
+}
+
 func TestWALRecovery(t *testing.T) {
 	_ = os.Remove("data.mdb")
 	_ = os.Remove("data.wal")

--- a/main.go
+++ b/main.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
+	"io"
+	"log"
+	"net/http"
 	"os"
 	"strings"
 
@@ -10,9 +14,26 @@ import (
 )
 
 func main() {
-	err := engine.Init()
-	if err != nil {
+	listen := flag.String("listen", "", "start HTTP server on this address")
+	flag.Parse()
+
+	if err := engine.Init(); err != nil {
 		fmt.Println("Error loading DB:", err)
+		return
+	}
+
+	if *listen != "" {
+		http.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
+			data, _ := io.ReadAll(r.Body)
+			res, err := engine.Execute(string(data))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(res))
+		})
+		log.Printf("Listening on %s", *listen)
+		log.Fatal(http.ListenAndServe(*listen, nil))
 		return
 	}
 


### PR DESCRIPTION
## Summary
- add HTTP server option in `main.go`
- extend `SELECT` handler with column selection and simple `WHERE`
- provide test for new `WHERE` feature

## Testing
- `make test`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68458d321a3c8329bfde2e7a42c153fe