### PR TITLE
Add transaction support

### DIFF
--- a/engine/serialize.go
+++ b/engine/serialize.go
@@ -19,9 +19,16 @@ const binaryDBFile = "data.mdb"
 const maxRowCount = 10_000_000
 
 func SaveBinaryDB() error {
+	if txCtx != nil {
+		return nil
+	}
 	dbMu.RLock()
 	defer dbMu.RUnlock()
 
+	return saveBinaryDBNoLock()
+}
+
+func saveBinaryDBNoLock() error {
 	file, err := os.OpenFile(binaryDBFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 
 	if err != nil {

--- a/engine/table.go
+++ b/engine/table.go
@@ -217,6 +217,9 @@ func handleSelect(query string) (string, error) {
 	var exists bool
 	if txCtx != nil {
 		table, exists = Tables[tableName]
+		if !exists {
+			return "", errors.New("table does not exist")
+		}
 	} else {
 		dbMu.RLock()
 		table, exists = Tables[tableName]

--- a/engine/table.go
+++ b/engine/table.go
@@ -99,9 +99,13 @@ func handleCreateTable(query string) (string, error) {
 		Rows:    []Row{},
 	}
 
-	dbMu.Lock()
-	Tables[header] = table
-	dbMu.Unlock()
+	if txCtx != nil {
+		Tables[header] = table
+	} else {
+		dbMu.Lock()
+		Tables[header] = table
+		dbMu.Unlock()
+	}
 
 	returnMsg := fmt.Sprintf("Table '%s' created.", header)
 
@@ -139,9 +143,15 @@ func handleInsert(query string) (string, error) {
 
 	vals := strings.Split(valuesRaw[open+1:close], ",")
 
-	dbMu.RLock()
-	table, exists := Tables[tableName]
-	dbMu.RUnlock()
+	var table *Table
+	var exists bool
+	if txCtx != nil {
+		table, exists = Tables[tableName]
+	} else {
+		dbMu.RLock()
+		table, exists = Tables[tableName]
+		dbMu.RUnlock()
+	}
 	if !exists {
 		return "", errors.New("table does not exist")
 	}
@@ -203,11 +213,17 @@ func handleSelect(query string) (string, error) {
 	}
 	tableName := strings.Fields(query[fromIdx+6:])[0]
 
-	dbMu.RLock()
-	table, exists := Tables[tableName]
-	if !exists {
-		dbMu.RUnlock()
-		return "", errors.New("table does not exist")
+	var table *Table
+	var exists bool
+	if txCtx != nil {
+		table, exists = Tables[tableName]
+	} else {
+		dbMu.RLock()
+		table, exists = Tables[tableName]
+		if !exists {
+			dbMu.RUnlock()
+			return "", errors.New("table does not exist")
+		}
 	}
 
 	colIdx := make([]int, 0, len(cols))
@@ -229,7 +245,9 @@ func handleSelect(query string) (string, error) {
 				}
 			}
 			if idx == -1 {
-				dbMu.RUnlock()
+				if txCtx == nil {
+					dbMu.RUnlock()
+				}
 				return "", fmt.Errorf("unknown column %s", c)
 			}
 			colIdx = append(colIdx, idx)
@@ -247,12 +265,16 @@ func handleSelect(query string) (string, error) {
 			}
 		}
 		if idx == -1 {
-			dbMu.RUnlock()
+			if txCtx == nil {
+				dbMu.RUnlock()
+			}
 			return "", fmt.Errorf("unknown column %s", whereCol)
 		}
 		parsed, err := parseValue(fmt.Sprint(whereVal), table.Columns[idx].Type)
 		if err != nil {
-			dbMu.RUnlock()
+			if txCtx == nil {
+				dbMu.RUnlock()
+			}
 			return "", fmt.Errorf("invalid %s value for column %s", table.Columns[idx].Type, whereCol)
 		}
 		whereIdxCol = idx
@@ -276,7 +298,9 @@ func handleSelect(query string) (string, error) {
 		builder.WriteString(strings.Join(strVals, "\t") + "\n")
 	}
 	table.mu.RUnlock()
-	dbMu.RUnlock()
+	if txCtx == nil {
+		dbMu.RUnlock()
+	}
 
 	return builder.String(), nil
 }
@@ -298,9 +322,15 @@ func handleUpdate(query string) (string, error) {
 
 	tableName := strings.TrimSpace(query[6:setIdx])
 
-	dbMu.RLock()
-	table, exists := Tables[tableName]
-	dbMu.RUnlock()
+	var table *Table
+	var exists bool
+	if txCtx != nil {
+		table, exists = Tables[tableName]
+	} else {
+		dbMu.RLock()
+		table, exists = Tables[tableName]
+		dbMu.RUnlock()
+	}
 	if !exists {
 		return "", errors.New("table does not exist")
 	}

--- a/engine/tx.go
+++ b/engine/tx.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"os"
+)
+
+// Tx represents a simple transaction holding pending WAL entries
+// and a snapshot of tables for rollback.
+type Tx struct {
+	wal      []string
+	snapshot map[string]*Table
+}
+
+var txCtx *Tx
+
+// BeginTx starts a new transaction and locks the database for exclusive access.
+func BeginTx() *Tx {
+	dbMu.Lock()
+	txCtx = &Tx{snapshot: cloneTables(Tables)}
+	return txCtx
+}
+
+// Exec executes a query within the transaction using the normal command handler.
+func (tx *Tx) Exec(query string) (string, error) { return HandleCommand(query) }
+
+// Commit writes all pending WAL entries and persists the DB to disk.
+func (tx *Tx) Commit() error {
+	// write accumulated WAL entries
+	walMu.Lock()
+	f, err := os.OpenFile(walFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		walMu.Unlock()
+		return err
+	}
+	for _, line := range tx.wal {
+		if _, err := f.WriteString(line + "\n"); err != nil {
+			_ = f.Close()
+			walMu.Unlock()
+			return err
+		}
+	}
+	_ = f.Close()
+	walMu.Unlock()
+
+	txCtx = nil
+	if err := saveBinaryDBNoLock(); err != nil {
+		dbMu.Unlock()
+		return err
+	}
+	if err := clearWAL(); err != nil {
+		dbMu.Unlock()
+		return err
+	}
+	dbMu.Unlock()
+	return nil
+}
+
+// Rollback restores the snapshot state and discards changes.
+func (tx *Tx) Rollback() {
+	Tables = tx.snapshot
+	txCtx = nil
+	dbMu.Unlock()
+}
+
+// cloneTables performs a deep copy of tables for transaction snapshots.
+func cloneTables(src map[string]*Table) map[string]*Table {
+	newMap := make(map[string]*Table, len(src))
+	for name, tbl := range src {
+		t := &Table{
+			Name:    tbl.Name,
+			Columns: append([]Column(nil), tbl.Columns...),
+			Rows:    make([]Row, len(tbl.Rows)),
+		}
+		for i, row := range tbl.Rows {
+			nr := make(Row, len(row))
+			copy(nr, row)
+			t.Rows[i] = nr
+		}
+		newMap[name] = t
+	}
+	return newMap
+}

--- a/engine/wal.go
+++ b/engine/wal.go
@@ -18,6 +18,10 @@ func appendWAL(entry string) error {
 	if walReplay {
 		return nil
 	}
+	if txCtx != nil {
+		txCtx.wal = append(txCtx.wal, entry)
+		return nil
+	}
 	walMu.Lock()
 	defer walMu.Unlock()
 	f, err := os.OpenFile(walFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
@@ -33,6 +37,9 @@ func appendWAL(entry string) error {
 
 func clearWAL() error {
 	if walReplay {
+		return nil
+	}
+	if txCtx != nil {
 		return nil
 	}
 	walMu.Lock()


### PR DESCRIPTION
## Summary
- implement basic transactional engine with table snapshot and WAL buffering
- update SQL driver to expose transactions
- conditionally lock database in table handlers
- adjust WAL and binary DB persistence for transactions
- test commit and rollback

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845944ffecc8329af576c5d9802152e